### PR TITLE
upgrade oauth2 gem

### DIFF
--- a/omniauth-harvest.gemspec
+++ b/omniauth-harvest.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.0.0'
+  s.add_runtime_dependency 'omniauth-oauth2', "~> 1.3.1"
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Make it match https://github.com/kmrshntr/omniauth-slack/blob/v2.3.0/omniauth-slack.gemspec

---

From #3 

The causes conflicts when trying to use other gems such as slack...

```
Bundler could not find compatible versions for gem "omniauth-oauth2":
  In snapshot (Gemfile.lock):
    omniauth-oauth2 (= 1.0.2)

  In Gemfile:
    omniauth-harvest was resolved to 0.1.0, which depends on
      omniauth-oauth2 (~> 1.0.0)

    omniauth-slack (~> 2.3) was resolved to 2.3.0, which depends on
      omniauth-oauth2 (~> 1.3.1)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

Is there something specific about this gem which is incompatible with the 1.3.x branch?